### PR TITLE
Bump peer dependencies to accept React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "^0.14.3 || ^15.0.0"
+    "react": "^0.14.3 || ^15.0.0 || ^16.0.0"
   },
   "browserify-shim": {
     "react": "global:React",


### PR DESCRIPTION
React 16 has been released: https://facebook.github.io/react/blog/2017/09/26/react-v16.0.html